### PR TITLE
Change directory before starting app

### DIFF
--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+cd /amscores/backend
 if [ "$DEPLOYMENT_GROUP_NAME" == "Production" ]; then
   export NODE_ENV=production
 else


### PR DESCRIPTION
In the start-server script, make sure the app is getting started while
in the backend directory so that the relative path to the .env file gets
used.