### PR TITLE
Shift `includes` to `indexOf`

### DIFF
--- a/lib/auth0_utils.js
+++ b/lib/auth0_utils.js
@@ -52,7 +52,7 @@ function getManagementClient() {
 function getAuth0Id(accId) {
   // returns the auth0_id field associated with the acct_id found in the 'Acct' table
   return query('SELECT auth0_id FROM Acct WHERE acct_id = ?', [accId]).then(function(data) {
-    if (data.length == 1 && Object.keys(data[0]).includes('auth0_id')) {
+    if (data.length == 1 && Object.keys(data[0]).indexOf('auth0_id') >= 0) {
       return data[0].auth0_id;
     } else {
       return createArgumentNotFoundError(accId, 'acct_id');
@@ -145,7 +145,7 @@ function updateAuth0UserFromParams(auth0Id, updateParams) {
   var updateKey;
   var updateValue;
   for (updateKey in updateParams) {
-    if (VALID_KEYS.includes(updateKey)) {
+    if (VALID_KEYS.indexOf(updateKey) >= 0) {
       updateValue = updateParams[updateKey];
       try {
         updates = addToAuth0Body(updates, updateKey, updateValue);
@@ -171,13 +171,13 @@ function updateAuth0User(auth0Id, updateBody) {
 }
 
 function addToAuth0Body(obj, key, value) {
-  if (VALID_UPDATE_KEYS.includes(key)) {
+  if (VALID_UPDATE_KEYS.indexOf(key) >= 0) {
     // update username, password, or email
     obj[key] = value;
-  } else if (VALID_USER_UPDATE_KEYS.includes(key)) {
+  } else if (VALID_USER_UPDATE_KEYS.indexOf(key) >= 0) {
     // update first or last name
     obj = addToMetadata(obj, USER_METADATA_KEY, key, value);
-  } else if (VALID_APP_UPDATE_KEYS.includes(key)) {
+  } else if (VALID_APP_UPDATE_KEYS.indexOf(key) >= 0) {
     // update acct_type
     obj = addToMetadata(obj, APP_METADATA_KEY, key, value);
   } else {
@@ -187,7 +187,7 @@ function addToAuth0Body(obj, key, value) {
 }
 
 function addToMetadata(obj, metadataType, key, value) {
-  if (!Object.keys(obj).includes(metadataType)) {
+  if (Object.keys(obj).indexOf(metadataType) < 0) {
     obj[metadataType] = {};
   }
   obj[metadataType][key] = value;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,7 @@
 const Promise = require('bluebird');
 const getSqlConnection = require('../config/connection').getSqlConnection;
 
-const AuthError = require('./errors').AuthError;
+// const AuthError = require('./errors').AuthError;
 const c = require('./constants/utils');
 const q = require('./constants/queries');
 
@@ -52,13 +52,15 @@ function isPositiveInteger(str) {
   return String(str).match(intRegex) != null;
 }
 
+/*
 function getReqAuth0Id(req) {
-  if (Object.keys(req).includes('auth') && Object.keys(req.auth).includes('auth0_id')) {
+  if (Object.keys(req).indexOf('auth') >= 0 && Object.keys(req.auth).indexOf('auth0_id') >= 0) {
     return req.auth.auth0_id;
   } else {
      throw new AuthError();
   }
 }
+*/
 
 function getAccountType(auth0_id) {
   return query('SELECT acct_type FROM Acct WHERE auth0_id = ?', [auth0_id]).then(function(acct_types) {
@@ -108,8 +110,8 @@ function reqHasRequirements(obj, reqs) {
 function findMissingRequirements(obj, reqs) {
   var keys = Object.keys(obj);
   return reqs.filter(function(req) {
-    return !keys.includes(req.type) ||
-      (req.name !== null && !Object.keys(obj[req.type]).includes(req.name));
+    return keys.indexOf(req.type) < 0 ||
+      (req.name !== null && Object.keys(obj[req.type]).indexOf(req.name) < 0);
   });
 }
 
@@ -172,7 +174,7 @@ function getSeasonId(dateString) {
 
 module.exports = {
   makeResponse, query, QueryError,
-  getAccountID, getAccountType, getReqAuth0Id,
+  getAccountID, getAccountType, // getReqAuth0Id,
   isValidDate, isPositiveInteger, defined,
   PotentialQuery, Requirement, makeQueryArgs, reqHasRequirements,
   findMissingRequirements, findEmptyRequirements, getSqlDateString,

--- a/routes/accounts.js
+++ b/routes/accounts.js
@@ -137,7 +137,7 @@ function updateAccount(req) {
 
       for (var i = 0; i < bodyKeys.length; i++) {
         bodyKey = bodyKeys[i];
-        if (UPDATE_KEYS.includes(bodyKey)) {
+        if (UPDATE_KEYS.indexOf(bodyKey) >= 0) {
           bodyValue = body[bodyKey];
           // Add to the query statement for our database
           setStatement += bodyKey + '="' + bodyValue + '",';
@@ -213,7 +213,7 @@ function createAccount(req) {
   var password = req.body.password;
 
   // if given an invalid account type, throw a 400
-  if (!ACCOUNT_TYPES.includes(acct_type)) {
+  if (ACCOUNT_TYPES.indexOf(acct_type) < 0) {
     return errors.create400({
       message: 'Account type must be one of: Admin, Coach, Staff, Volunteer'
     });

--- a/test/lib/auth0_utils.js
+++ b/test/lib/auth0_utils.js
@@ -66,7 +66,7 @@ function testCreateError(props, done) {
   var tester = Object.assign({}, TEST_USER);
   var key;
   for (key in props) {
-    if (VALID_USER_KEYS.includes(key)) {
+    if (VALID_USER_KEYS.indexOf(key) > 0) {
       tester[key] = props[key];
     }
   };

--- a/test/routes/reports.js
+++ b/test/routes/reports.js
@@ -68,7 +68,6 @@ describe('Reports', function() {
             data.post_pacer
           ));
         }).on('end', function() {
-          console.log(results);
           done();
         });
     });


### PR DESCRIPTION
Because `includes` isn't as widely supported by browsers as `indexOf`,
shift all remaining instances to use `indexOf` instead. Also comments
out a vestige of attempting to get auth working that isn't used anymore
and removes an extraneous logging statement used for debugging.