### PR TITLE
Pull Auth0 ids out of constants

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,7 +26,7 @@ app.use(bodyParser.urlencoded({extended: true}));
 app.use(function(req, res, next) {
   res.header('Access-Control-Allow-Origin', '*');
   res.header('Access-Control-Allow-Methods', 'POST, GET, OPTIONS, PUT, DELETE');
-  res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+  res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
   next();
 });
 

--- a/lib/constants/auth0.js
+++ b/lib/constants/auth0.js
@@ -1,16 +1,22 @@
 'use strict';
-// TODO: REMAKE THE AUTH0 ACCOUNTS AND STICK THE IDEAS IN THE ENVIRONMENT (TRAVIS) OR A .ENV FILE
-const ACCT1_AUTH0_ID = 'auth0|584377c428be27504a2bcf92';
-const ACCT2_AUTH0_ID = 'auth0|58437854a26376e37529be0d';
-const ACCT3_AUTH0_ID = 'auth0|5843788eda0529cd293da8e3';
-const ACCT4_AUTH0_ID = 'auth0|584378b528be27504a2bcf98';
-const ACCT5_AUTH0_ID = 'auth0|584378dda26376e37529be0f';
-const ACCT6_AUTH0_ID = 'auth0|5843790aa7972b6f752e07d9';
-const ACCT7_AUTH0_ID = 'auth0|5843792b28be27504a2bcfa0';
-const ACCT8_AUTH0_ID = 'auth0|58437948dff6306470568bd5';
-const ACCT9_AUTH0_ID = 'auth0|5843796a28be27504a2bcfa1';
+const dotenv = require('dotenv');
+// Travis doesn't see the .env file; it has the token/domain as env variables already
+const fs = require('fs');
+if (fs.existsSync('./.env')) {
+  dotenv.load();
+}
 
-const DEMO_ACCT1_AUTH0_ID = 'auth0|58ee52429a74e078332bcdea';
+const ACCT1_AUTH0_ID = process.env.ACCT1_AUTH0_ID;
+const ACCT2_AUTH0_ID = process.env.ACCT2_AUTH0_ID;
+const ACCT3_AUTH0_ID = process.env.ACCT3_AUTH0_ID;
+const ACCT4_AUTH0_ID = process.env.ACCT4_AUTH0_ID;
+const ACCT5_AUTH0_ID = process.env.ACCT5_AUTH0_ID;
+const ACCT6_AUTH0_ID = process.env.ACCT6_AUTH0_ID;
+const ACCT7_AUTH0_ID = process.env.ACCT7_AUTH0_ID;
+const ACCT8_AUTH0_ID = process.env.ACCT8_AUTH0_ID;
+const ACCT9_AUTH0_ID = process.env.ACCT9_AUTH0_ID;
+
+const DEMO_ACCT1_AUTH0_ID = process.env.DEMO_ACCT1_AUTH0_ID;
 
 const ADMIN_AUTH0_ID = ACCT7_AUTH0_ID;
 const STAFF_AUTH0_ID = ACCT5_AUTH0_ID;

--- a/lib/constants/seed.js
+++ b/lib/constants/seed.js
@@ -91,15 +91,15 @@ const TEST_STUDENT_TO_PROGRAMS = [
   STUDENT_TO_PROGRAM_4,
 ];
 
-const ACCT_1 = new Acct('Ron', 'Large', 'ronlarge@americascores.org', COACH, ACCT1_AUTH0_ID, 1);
-const ACCT_2 = new Acct('Marcel', 'Yogg', 'myogg@americascores.org', COACH, ACCT2_AUTH0_ID, 2);
-const ACCT_3 = new Acct('Maggie', 'Pam', 'mp@americascores.org', VOLUNTEER, ACCT3_AUTH0_ID, 3);
-const ACCT_4 = new Acct('Jeff', 'Nguyen', 'jnguyen@americascores.org', VOLUNTEER, ACCT4_AUTH0_ID, 4);
-const ACCT_5 = new Acct('Larry', 'Mulligan', 'lmulligan@americascores.org', STAFF, ACCT5_AUTH0_ID, 5);
-const ACCT_6 = new Acct('Jake', 'Sky', 'blue@americascores.org', STAFF, ACCT6_AUTH0_ID, 6);
-const ACCT_7 = new Acct('Mark', 'Pam', 'redsoxfan@americascores.org', ADMIN, ACCT7_AUTH0_ID, 7);
-const ACCT_8 = new Acct('Amanda', 'Diggs', 'adiggs@americascores.org', ADMIN, ACCT8_AUTH0_ID, 8);
-const ACCT_9 = new Acct('Tom', 'Lerner', 'tlerner@americascores.org', COACH, ACCT9_AUTH0_ID, 9);
+const ACCT_1 = new Acct('Ron', 'Large', 'asb_test_user_1@americascores.org', COACH, ACCT1_AUTH0_ID, 1);
+const ACCT_2 = new Acct('Marcel', 'Yogg', 'asb_test_user_2@americascores.org', COACH, ACCT2_AUTH0_ID, 2);
+const ACCT_3 = new Acct('Maggie', 'Pam', 'asb_test_user_3@americascores.org', VOLUNTEER, ACCT3_AUTH0_ID, 3);
+const ACCT_4 = new Acct('Jeff', 'Nguyen', 'asb_test_user_4@americascores.org', VOLUNTEER, ACCT4_AUTH0_ID, 4);
+const ACCT_5 = new Acct('Larry', 'Mulligan', 'asb_test_user_5@americascores.org', STAFF, ACCT5_AUTH0_ID, 5);
+const ACCT_6 = new Acct('Jake', 'Sky', 'asb_test_user_6@americascores.org', STAFF, ACCT6_AUTH0_ID, 6);
+const ACCT_7 = new Acct('Mark', 'Pam', 'asb_test_user_7@americascores.org', ADMIN, ACCT7_AUTH0_ID, 7);
+const ACCT_8 = new Acct('Amanda', 'Diggs', 'asb_test_user_8@americascores.org', ADMIN, ACCT8_AUTH0_ID, 8);
+const ACCT_9 = new Acct('Tom', 'Lerner', 'asb_test_user_9@americascores.org', COACH, ACCT9_AUTH0_ID, 9);
 
 const TEST_ACCTS = [
   ACCT_1,
@@ -284,7 +284,7 @@ const DEMO_STUDENT_TO_PROGRAMS = [
   DEMO_STUDENT_TO_PROGRAM_20,
 ];
 
-const DEMO_ACCT_1 = new Acct('Bob', 'Smith', 'demo_admin@americascores.org', ADMIN, auth0.DEMO_ACCT1_AUTH0_ID, 1);
+const DEMO_ACCT_1 = new Acct('Bob', 'Smith', 'asb_demo_user_1@americascores.org', ADMIN, auth0.DEMO_ACCT1_AUTH0_ID, 1);
 
 const DEMO_ACCTS = [
   DEMO_ACCT_1,

--- a/test/lib/auth0_utils.js
+++ b/test/lib/auth0_utils.js
@@ -10,7 +10,7 @@ const testUtils = require('../../lib/test_utils');
 const assertEqualError = testUtils.assertEqualError;
 const assertEqualAuth0DB = testUtils.assertEqualAuth0DBAcct;
 
-const EXISTING_USERNAME = 'test1';
+const EXISTING_USERNAME = 'asb_test_user_1';
 const ACCT = Object.assign({username: EXISTING_USERNAME}, require('../../lib/constants/seed').ACCT_1);
 const AUTH0_ID = ACCT.auth0_id;
 

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -11,6 +11,8 @@ const q = require('../../lib/constants/queries');
 const a = require('../../lib/constants/auth0');
 const c = require('../../lib/constants/utils');
 
+const AUTH0_ID = a.ACCT1_AUTH0_ID;
+
 const assertEqualError = require('../../lib/test_utils').assertEqualError;
 
 const res = {
@@ -147,7 +149,7 @@ describe('utils', function() {
 
   describe('getAccountID()', function() {
     it('gets the account id for a auth0_id', function(done) {
-      utils.getAccountID('auth0|584377c428be27504a2bcf92').then(function(data) {
+      utils.getAccountID(AUTH0_ID).then(function(data) {
         assert.equal(data, 1);
         done();
       });


### PR DESCRIPTION
New Auth0 accounts for testing have been generated, and their Auth0 ids
are no longer visible in the source code - they are locked in the Travis
environment variables/the server .env files.

[AS-317]